### PR TITLE
Fix PWA hijacking trailing-slash URLs to home page

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -63,7 +63,14 @@ export default defineNuxtConfig({
       ],
     },
     workbox: {
-      navigateFallback: '/',
+      // Disable the navigation fallback. This is an SSG site with a precached
+      // HTML file per route, so navigation requests should fall through to the
+      // network (or matching precache entry) — not a single SPA shell. With a
+      // fallback set, any URL not matching a precache entry exactly (e.g.
+      // /posts/ with trailing slash) gets the home page instead of the right
+      // page. Note: @vite-pwa/nuxt defaults this to '/' if the key is absent,
+      // so we must set it explicitly (null cast — Workbox accepts no value).
+      navigateFallback: null as unknown as string,
       globPatterns: ['**/*.{js,css,html,png,svg,ico,woff2,webmanifest}'],
     },
     client: {


### PR DESCRIPTION
## Summary
Returning visitors with the PWA service worker installed see the home page when they navigate to any URL with a trailing slash — `/posts/`, `/covenant/`, `/posts/2026-01-social/`, etc. Reported by @zepterfd  (re: `/posts/`), reproduced in Playwright.

## Root cause
The generated `sw.js` registered a single NavigationRoute pointed at the precached `/` page:

```js
registerRoute(new NavigationRoute(createHandlerBoundToURL("/")))
```

Workbox writes precache entries **without** trailing slashes (`"posts"`, `"covenant"`, etc.). So:
- `/posts` matches precache entry `"posts"` → serves the posts page ✅
- `/posts/` does **not** match → falls through to NavigationRoute → serves the home page ❌

This is the SPA pattern — wrong for an SSG site that has a real `index.html` precached for every route.

## Fix
One-line change in `nuxt.config.ts`: explicitly disable the navigation fallback.

`@vite-pwa/nuxt` defaults `navigateFallback` to `/` when the key is **absent** (see `node_modules/@vite-pwa/nuxt/dist/shared/nuxt.*.mjs` — `if (!("navigateFallback" in options.workbox)) ...`). So simply removing the line didn't help — I had to set the key with a falsy value to suppress the default. A comment explains why so a future contributor doesn't put it back.

Without the fallback:
- Online visitors: navigation requests not in precache fall through to the network → GitHub Pages serves the right HTML.
- Offline visitors hitting a non-precached URL: browser network error (acceptable for a community site — pure offline support isn't a goal).

## Verification
- `yarn generate` → confirmed `NavigationRoute` no longer appears in `sw.js`.
- Local serve + Playwright with SW in control:
  - `/posts/` → "The Woodmont Warbler" ✅
  - `/posts/2026-01-social/` → "Woodmont Civic Association Social - January 15th" ✅
  - `/covenant/` → "Neighborhood Covenant" ✅
  - `/posts` (no slash) → "The Woodmont Warbler" ✅ (still works)
- On main today, the same test landed at `/` with title "Woodmont Civic Association" — exactly the reported bug.

## Note on SEO
Search engines never run service workers; they hit GitHub Pages directly and always saw the right pages. This bug only affected returning human visitors who had the SW installed. So no Google de-indexing risk — but the user experience was clearly broken.

## Test plan
- [ ] CI green
- [ ] After merge, in a normal browser: visit `https://woodmontbonair.com/`, then navigate to `https://woodmontbonair.com/posts/` and confirm the Warbler page loads (not home).
- [ ] Hard-refresh `/posts/` and confirm it still loads correctly (SW should update via `registerType: 'autoUpdate'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)