### PR TITLE
Fix trailing-slash mismatch in canonicals and sitemap

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -68,6 +68,14 @@ export default defineNuxtConfig({
     name: 'Woodmont Civic Association',
     description: 'Official site of the Woodmont Civic Association — news, events, and resources for the Woodmont neighborhood of Bon Air, VA.',
     defaultLocale: 'en',
+    // GitHub Pages serves directory routes at the trailing-slash form and 301s
+    // /foo → /foo/. Without this, @nuxtjs/sitemap emits /posts/X and
+    // nuxt-seo-utils sets <link rel="canonical" href=".../posts/X">, both of
+    // which redirect to the slash form Google actually serves. That mismatch
+    // is what GSC flags as "Page with redirect" + "Duplicate without
+    // user-selected canonical". Setting this makes both modules emit the
+    // /foo/ form so the canonical, sitemap, and served URL all agree.
+    trailingSlash: true,
   },
   sitemap: {
     exclude: ['/gallery', '/history', '/news/**'],


### PR DESCRIPTION
## Summary

Adds `site.trailingSlash: true` to `nuxt.config.ts` so `@nuxtjs/sitemap` and `nuxt-seo-utils` emit URLs with the trailing slash — matching what GitHub Pages actually serves.

## Why

GSC's May 21 Page Indexing report flagged 5 issue categories. Diagnosis: GitHub Pages serves directory routes at `/foo/` and 301-redirects `/foo` → `/foo/`. The SEO modules added in #65/#67 defaulted to the no-slash form, producing a self-defeating canonical on every page:

- Sitemap entry: `/posts/2023-06`
- Served at: `/posts/2023-06/` (after 301)
- Canonical tag: `/posts/2023-06` (redirects away from the page itself)

Google's response, per the [GSC report](#):
- **"Page with redirect"** — every sitemap URL except `/` 301s
- **"Duplicate without user-selected canonical"** — canonical points at the redirect source, not the served URL
- **"Crawled - currently not indexed" (9 pages)** — Google defers indexing on canonical confusion

You can reproduce on the live site today: `curl -sL https://woodmontbonair.com/posts/2023-06/ | grep canonical` returns `<link rel="canonical" href="https://woodmontbonair.com/posts/2023-06">` (no slash), and `curl -sI https://woodmontbonair.com/posts/2023-06` returns `HTTP/2 301`.

The indexed-page trend in the GSC chart (7 → 3 since February) suggests this canonical signal has been pushing Google away for months — the May 19 SEO module additions actually made it more legible to Google, but with the wrong canonical form.

## What changed

Eight lines in [nuxt.config.ts](nuxt.config.ts) — one config key plus a comment explaining why.

```ts
site: {
  url: 'https://woodmontbonair.com',
  // ...
  trailingSlash: true,   // new
},
```

Both `@nuxtjs/sitemap` and `nuxt-seo-utils` read from `nuxt-site-config`, so the single key fixes both.

## Verified locally

`yarn generate` against this branch:

| | Before | After |
|---|---|---|
| Sitemap entries | `/posts/2023-06`, `/covenant`, `/registration`, … | `/posts/2023-06/`, `/covenant/`, `/registration/`, … |
| Canonical tags | `href="https://woodmontbonair.com/covenant"` | `href="https://woodmontbonair.com/covenant/"` |

All 11 sitemap URLs and every canonical tag now end with `/`, matching what GitHub Pages serves. No 301 from any canonical URL.

## What this does NOT address

- **"Not found (404)" (1 page)** — your May 18 [d549ac4](https://github.com/woodmont-civic/woodmont-civic.github.io/commit/d549ac4) rename intentionally accepted that old `/posts/YYYY_MM` URLs would 404. Not worth recovering for board-meeting stubs.
- **"Blocked by robots.txt" (1 page)** — likely stale data from before #67 added robots.txt. Current robots.txt is fully open; should self-clear on recrawl.
- **Some of "Crawled - currently not indexed"** — partly the canonical issue (will improve), partly that old posts like `2020.md` are genuinely thin. Optional follow-up: add `noindex` to pre-2025 posts to tell Google to stop trying.

## Test plan

- [ ] Merge → wait for the GH Pages deploy
- [ ] `curl -sL https://woodmontbonair.com/posts/2023-06/ | grep canonical` returns the slash form
- [ ] `curl https://woodmontbonair.com/sitemap.xml` shows trailing slashes on every non-home URL
- [ ] In GSC → Page Indexing → click "Validate Fix" on each affected reason
- [ ] Resubmit sitemap in GSC
- [ ] Recheck in ~2 weeks; expect indexed count to climb and the redirect/duplicate buckets to clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)