### PR TITLE
Add GitHub, Facebook, Nextdoor icons to navbar

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -4,6 +4,7 @@ export default defineAppConfig({
   socials: {
     github: 'woodmont-civic/woodmont-civic.github.io',
     facebook: 'https://www.facebook.com/search/top/?q=woodmont%20civic%20association',
+    nextdoor: 'https://nextdoor.com/neighborhood/woodmontnorthchesterfield--north-chesterfield--va/',
   },
   prose: {
     h1: {

--- a/components/AppNavbar.vue
+++ b/components/AppNavbar.vue
@@ -74,8 +74,9 @@ onMounted(() => {
     </div>
     <!-- Social icons & Color Mode -->
     <div class="space-x-3 transition text-gray-500 flex items-center shrink-0">
-      <a v-if="appConfig.socials?.twitter" :href="`https://twitter.com/${appConfig.socials?.twitter}`" title="Twitter" class="dark:text-gray-100 hover:text-gray-700 dark:hover:text-gray-300"><Icon name="fa-brands:twitter" class="w-5 h-5" /></a>
-      <a v-if="appConfig.socials?.mastodon" :href="`https://elk.zone/${appConfig.socials?.mastodon}`" title="Mastodon" class="dark:text-gray-100 hover:text-gray-700 dark:hover:text-gray-300"><Icon name="fa-brands:mastodon" class="w-5 h-5" /></a>
+      <a v-if="appConfig.socials?.facebook" :href="appConfig.socials?.facebook" target="_blank" rel="noopener" title="Facebook" class="dark:text-gray-100 hover:text-gray-700 dark:hover:text-gray-300"><Icon name="fa-brands:facebook" class="w-5 h-5" /></a>
+      <a v-if="appConfig.socials?.nextdoor" :href="appConfig.socials?.nextdoor" target="_blank" rel="noopener" title="Nextdoor" class="dark:text-gray-100 hover:text-gray-700 dark:hover:text-gray-300"><Icon name="fa-brands:nextdoor" class="w-5 h-5" /></a>
+      <a v-if="appConfig.socials?.github" :href="`https://github.com/${appConfig.socials?.github}`" target="_blank" rel="noopener" title="GitHub" class="dark:text-gray-100 hover:text-gray-700 dark:hover:text-gray-300"><Icon name="fa-brands:github" class="w-5 h-5" /></a>
       <ColorModeSwitch class="dark:text-gray-100 hover:text-gray-700 dark:hover:text-gray-300" />
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Adds GitHub, Facebook, and Nextdoor social icons to the navbar's existing social row
- Removes Twitter and Mastodon icons (we don't have accounts on either)
- Adds the Nextdoor neighborhood URL to `app.config.ts` (share-tracking params stripped)

The GitHub URL was already configured in `app.config.ts` but the local `AppNavbar.vue` override never rendered it. This wires up the channels WCA actually uses.

Closes #76

## Test plan
- [ ] `yarn dev` and confirm three icons render in the navbar (GitHub, Facebook, Nextdoor) on light + dark mode
- [ ] Click each icon and verify it opens the correct destination in a new tab
- [ ] Confirm Twitter and Mastodon icons no longer appear
- [ ] Spot-check that the navbar layout doesn't break on mobile widths


---
_Generated by [Claude Code](https://claude.ai/code/session_01Aja3wKCA1vNHn4HFwBWhxP)_