### PR TITLE
Fix Nextdoor icon rendering as literal text in navbar

### DIFF
--- a/components/AppNavbar.vue
+++ b/components/AppNavbar.vue
@@ -75,7 +75,7 @@ onMounted(() => {
     <!-- Social icons & Color Mode -->
     <div class="space-x-3 transition text-gray-500 flex items-center shrink-0">
       <a v-if="appConfig.socials?.facebook" :href="appConfig.socials?.facebook" target="_blank" rel="noopener" title="Facebook" class="dark:text-gray-100 hover:text-gray-700 dark:hover:text-gray-300"><Icon name="fa-brands:facebook" class="w-5 h-5" /></a>
-      <a v-if="appConfig.socials?.nextdoor" :href="appConfig.socials?.nextdoor" target="_blank" rel="noopener" title="Nextdoor" class="dark:text-gray-100 hover:text-gray-700 dark:hover:text-gray-300"><Icon name="fa-brands:nextdoor" class="w-5 h-5" /></a>
+      <a v-if="appConfig.socials?.nextdoor" :href="appConfig.socials?.nextdoor" target="_blank" rel="noopener" title="Nextdoor" class="dark:text-gray-100 hover:text-gray-700 dark:hover:text-gray-300"><Icon name="simple-icons:nextdoor" class="w-5 h-5" /></a>
       <a v-if="appConfig.socials?.github" :href="`https://github.com/${appConfig.socials?.github}`" target="_blank" rel="noopener" title="GitHub" class="dark:text-gray-100 hover:text-gray-700 dark:hover:text-gray-300"><Icon name="fa-brands:github" class="w-5 h-5" /></a>
       <ColorModeSwitch class="dark:text-gray-100 hover:text-gray-700 dark:hover:text-gray-300" />
     </div>


### PR DESCRIPTION
## Summary
Follow-up to #78. The `fa-brands` Iconify collection (FA5 era) doesn't ship a Nextdoor mark, so `<Icon name="fa-brands:nextdoor">` was falling back to rendering the icon name as plain text — which then overflowed and broke the navbar layout on mobile.

Swap to `simple-icons:nextdoor`, which has the brand glyph.

## Test plan
- [ ] `yarn dev` and confirm the Nextdoor icon renders as a logo (not text) in both light and dark mode
- [ ] Verify mobile layout: navbar no longer wraps awkwardly
- [ ] Confirm the link still opens the correct Nextdoor neighborhood page in a new tab


---
_Generated by [Claude Code](https://claude.ai/code/session_01Aja3wKCA1vNHn4HFwBWhxP)_